### PR TITLE
Add npm start command to start webpack dev server conveniently

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "webpack-dev-server": "^3.7.1"
   },
   "scripts": {
+    "start": "webpack-dev-server",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
## Summary

Per title. It'll be much easier to start the server by doing `npm start` than having to type the command `node_modules/.bin/webpack-dev-server`.

## Test Plan

```
# yangshun @ yangshun-mbp in ~/Developer/verticaltowerdefense on git:master x [5:35:22] 
$ npm start       

> vertical-tower-defense@1.0.0 start /Users/yangshun/Developer/verticaltowerdefense
> webpack-dev-server

ℹ ｢wds｣: Project is running at http://localhost:8080/
ℹ ｢wds｣: webpack output is served from /
ℹ ｢wds｣: Content not from webpack is served from /Users/yangshun/Developer/verticaltowerdefense
```